### PR TITLE
fix(genString): respect `singleQuotes` option

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -1,11 +1,15 @@
 import type { CodegenOptions } from "./types";
 
 export function genString(input: string, options: CodegenOptions = {}) {
-  const string_ = JSON.stringify(input);
-  if (!options.singleQuotes) {
-    return JSON.stringify(input);
+  const { singleQuotes = false } = options;
+
+  let string_ = JSON.stringify(input);
+  if (singleQuotes) {
+    string_ = escapeString(string_);
+    // JSON.stringify will always use double quotes, so we need to replace them
+    string_ = `'${string_.slice(1, -1)}'`;
   }
-  return `'${escapeString(string_)}'`;
+  return string_;
 }
 
 // https://github.com/rollup/rollup/blob/master/src/utils/escapeId.ts

--- a/src/string.ts
+++ b/src/string.ts
@@ -1,15 +1,11 @@
 import type { CodegenOptions } from "./types";
 
 export function genString(input: string, options: CodegenOptions = {}) {
-  const { singleQuotes = false } = options;
-
-  let string_ = JSON.stringify(input);
-  if (singleQuotes) {
-    string_ = escapeString(string_);
-    // JSON.stringify will always use double quotes, so we need to replace them
-    string_ = `'${string_.slice(1, -1)}'`;
+  const str = JSON.stringify(input);
+  if (!options.singleQuotes) {
+    return str;
   }
-  return string_;
+  return `'${escapeString(str).slice(1, -1)}'`;
 }
 
 // https://github.com/rollup/rollup/blob/master/src/utils/escapeId.ts

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -17,6 +17,11 @@ const genImportTests = [
   { names: "foo", code: 'import foo from "pkg";' },
   { names: ["foo"], code: 'import { foo } from "pkg";' },
   {
+    names: "foo",
+    code: `import foo from 'pkg';`,
+    options: { singleQuotes: true },
+  },
+  {
     names: [{ name: "foo", as: "bar" }],
     code: 'import { foo as bar } from "pkg";',
   },


### PR DESCRIPTION
Fixes #76

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#76 
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The following code would generate:
```ts
genImport('@eslint/js', 'js', { singleQuotes: true })
// import js from '"@eslint/js"';
```

The error comes from the use of `JSON.stringify` which wraps string into `"`. We just replace it with `'` if the options is set

Resolves #76 


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
