### PR TITLE
feat(esm): support new import attributes syntax

### DIFF
--- a/src/esm.ts
+++ b/src/esm.ts
@@ -7,9 +7,9 @@ export type ESMImport = string | { name: string; as?: string };
 export interface ESMCodeGenOptions extends CodegenOptions {
   // https://github.com/tc39/proposal-import-attributes
   // https://nodejs.org/api/esm.html#import-attributes
-  attributes?: { type: string; };
+  attributes?: { type: string };
   /** @deprecated use attributes */
-  assert?: { type: string; };
+  assert?: { type: string };
 }
 
 export function genImport(
@@ -101,18 +101,21 @@ function _genStatement(
   )}${_genImportAttributes(type, options)};`;
 }
 
-function _genImportAttributes(type: ImportExportType, options: ESMCodeGenOptions) {
+function _genImportAttributes(
+  type: ImportExportType,
+  options: ESMCodeGenOptions,
+) {
   // import assertions isn't specified type-only import or export on Typescript
   if (type === "import type" || type === "export type") {
     return "";
   }
 
-  if (typeof options.attributes?.type === 'string') {
+  if (typeof options.attributes?.type === "string") {
     return ` with { type: ${genString(options.attributes.type)} }`;
   }
 
   // TODO: Remove deprecated `assert` in the next major release
-  if (typeof options.assert?.type === 'string') {
+  if (typeof options.assert?.type === "string") {
     return ` assert { type: ${genString(options.assert.type)} }`;
   }
 
@@ -142,11 +145,11 @@ export function genDynamicImport(
 
 function _genDynamicImportAttributes(options: DynamicImportOptions = {}) {
   // TODO: Remove deprecated `assert` in the next major release
-  if (typeof options.assert?.type === 'string') {
+  if (typeof options.assert?.type === "string") {
     return `, { assert: { type: ${genString(options.assert.type)} } }`;
   }
 
-  if (typeof options.attributes?.type === 'string') {
+  if (typeof options.attributes?.type === "string") {
     return `, { with: { type: ${genString(options.attributes.type)} } }`;
   }
 

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -12,6 +12,12 @@ export interface ESMCodeGenOptions extends CodegenOptions {
   assert?: { type: string };
 }
 
+export interface DynamicImportOptions extends ESMCodeGenOptions {
+  comment?: string;
+  wrapper?: boolean;
+  interopDefault?: boolean;
+}
+
 export function genImport(
   specifier: string,
   imports?: ESMImport | ESMImport[],
@@ -122,11 +128,6 @@ function _genImportAttributes(
   return "";
 }
 
-export interface DynamicImportOptions extends ESMCodeGenOptions {
-  comment?: string;
-  wrapper?: boolean;
-  interopDefault?: boolean;
-}
 export function genDynamicImport(
   specifier: string,
   options: DynamicImportOptions = {},

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,4 @@
 export interface CodegenOptions {
   singleQuotes?: boolean;
-  // https://github.com/tc39/proposal-import-assertions
-  // https://tc39.es/proposal-import-assertions/
-  assert?: {
-    type: string;
-  };
+
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
 export interface CodegenOptions {
   singleQuotes?: boolean;
-
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -36,6 +36,11 @@ const genImportTests = [
     code: 'import { foo } from "pkg" assert { type: "json" };',
     options: { assert: { type: "json" } },
   },
+  {
+    names: ["foo"],
+    code: 'import { foo } from "pkg" with { type: "json" };',
+    options: { attributes: { type: "json" } },
+  },
 ];
 
 describe("genImport", () => {
@@ -86,6 +91,10 @@ const genDynamicImportTests = [
   {
     opts: { assert: { type: "json" } },
     code: '() => import("pkg", { assert: { type: "json" } })',
+  },
+  {
+    opts: { attributes: { type: "json" } },
+    code: '() => import("pkg", { with: { type: "json" } })',
   },
 ];
 


### PR DESCRIPTION
This PR improves type scope and moves to the new [imports attribute](https://nodejs.org/api/esm.html#import-attributes) proposal for codegen utils using new nonconflicting `attributes.type` option to keep backward compatibility until v2.