### PR TITLE
feat: add support for file extensions in genString function

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -6,19 +6,16 @@ import type { CodegenOptions } from "./types";
  * @group string
  */
 export function genString(input: string, options: CodegenOptions = {}) {
+  if (options.extension) {
+    input = input + "." + options.extension;
+  }
+
   const str = JSON.stringify(input);
   if (!options.singleQuotes) {
-    if (options.extension) {
-      return str + "." + options.extension;
-    }
     return str;
   }
-  const singleQuotedStr = `'${escapeString(str).slice(1, -1)}'`;
 
-  if (options.extension) {
-    return singleQuotedStr + "." + options.extension;
-  }
-  return singleQuotedStr;
+  return `'${escapeString(str).slice(1, -1)}'`;
 }
 
 // https://github.com/rollup/rollup/blob/master/src/utils/escapeId.ts

--- a/src/string.ts
+++ b/src/string.ts
@@ -8,9 +8,17 @@ import type { CodegenOptions } from "./types";
 export function genString(input: string, options: CodegenOptions = {}) {
   const str = JSON.stringify(input);
   if (!options.singleQuotes) {
+    if (options.extension) {
+      return str + "." + options.extension;
+    }
     return str;
   }
-  return `'${escapeString(str).slice(1, -1)}'`;
+  const singleQuotedStr = `'${escapeString(str).slice(1, -1)}'`;
+
+  if (options.extension) {
+    return singleQuotedStr + "." + options.extension;
+  }
+  return singleQuotedStr;
 }
 
 // https://github.com/rollup/rollup/blob/master/src/utils/escapeId.ts

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,8 @@
 export interface CodegenOptions {
   singleQuotes?: boolean;
+  /**
+   * @example
+   * 'ts', 'json', 'json5'
+   */
+  extension?: string;
 }

--- a/test/string.test.ts
+++ b/test/string.test.ts
@@ -24,3 +24,28 @@ describe("genString (singleQuotes: true)", () => {
     });
   }
 });
+
+// Tests for extension option
+const genStringExtensionTests = [
+  [`foo`, `ts`, `"foo.ts"`, `'foo.ts'`],
+  [`bar`, `json`, `"bar.json"`, `'bar.json'`],
+  [`baz`, `json5`, `"baz.json5"`, `'baz.json5'`],
+];
+
+describe("genString (with extension)", () => {
+  for (const [input, extension, output] of genStringExtensionTests) {
+    it(genTestTitle(`${input} with extension ${extension}`), () => {
+      expect(genString(input, { extension })).to.equal(output);
+    });
+  }
+});
+
+describe("genString (singleQuotes: true with extension)", () => {
+  for (const [input, extension, _, output] of genStringExtensionTests) {
+    it(genTestTitle(`${input} with extension ${extension}`), () => {
+      expect(genString(input, { singleQuotes: true, extension })).to.equal(
+        output,
+      );
+    });
+  }
+});


### PR DESCRIPTION
```
// Without extension
genString("file") // Returns: "file"
genString("file", { singleQuotes: true }) // Returns: 'file'

// With extension
genString("file", { extension: "ts" }) // Returns: "file.ts"
genString("file", { singleQuotes: true, extension: "json" }) // Returns: 'file.json'
``` 