### PR TITLE
fix: remove commas in module augmentation

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -112,5 +112,8 @@ export function genAugmentation(
           ? genInterface(key, ...entry)
           : genInterface(key, entry, {}, "  ")),
     ),
+    undefined,
+    undefined,
+    false,
   )}`;
 }

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -62,6 +62,13 @@ const genAugmentationTests: Array<{
 }`,
   },
   {
+    input: ["@nuxt/utils", { MyInterface: {}, MyOtherInterface: {} }],
+    code: `declare module "@nuxt/utils" {
+  interface MyInterface {}
+  interface MyOtherInterface {}
+}`,
+  },
+  {
     input: [
       "@nuxt/utils",
       {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
When passing multiple interfaces to `genAugmentation`, the interfaces will be comma separated, it looks like this behavior has been present for a while 🤔 

With the following function call:
```ts
genAugmentation("@nuxt/utils", { MyInterface: {}, MyOtherInterface: {} })
```

Current output:
```ts
declare module "@nuxt/utils" {
  interface MyInterface {}, // comma
  interface MyOtherInterface {}
}
```

Output with these changes:
```ts
declare module "@nuxt/utils" {
  interface MyInterface {} // no comma
  interface MyOtherInterface {}
}
```