### PR TITLE
feat: add genEnum for typescript enum codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ Generate a string with double or single quotes and handle escapes.
 
 Generate typescript `declare module` augmentation.
 
+### `genEnum(name, members, options, indent)`
+
+Generate typescript enum.
+
 ### `genInlineTypeImport(specifier, name, options)`
 
 Generate an typescript `typeof import()` statement for default import.

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -108,9 +108,16 @@ export function genEnum(
   indent = "",
 ): string {
   const newIndent = indent + "  ";
+  let previousValue: string | number | undefined;
   const body = wrapInDelimiters(
     Object.entries(members).map(([key, value]) => {
       const member = `${newIndent}${genObjectKey(key)}`;
+      if (value === undefined && typeof previousValue === "string") {
+        throw new TypeError(
+          `Enum member "${key}" must have an initializer because it follows a string-initialized member.`,
+        );
+      }
+      previousValue = value;
       if (value === undefined) {
         return member;
       }

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -10,6 +10,10 @@ export interface GenInterfaceOptions {
   extends?: string | string[];
   export?: boolean;
 }
+export interface GenEnumOptions {
+  export?: boolean;
+  const?: boolean;
+}
 
 /**
  * Generate a typescript `export type` statement.
@@ -90,6 +94,41 @@ export function genInterface(
     .filter(Boolean)
     .join(" ");
   return result;
+}
+
+/**
+ * Generate typescript enum.
+ *
+ * @group Typescript
+ */
+export function genEnum(
+  name: string,
+  members: Record<string, string | number | undefined>,
+  options: GenEnumOptions = {},
+  indent = "",
+): string {
+  const newIndent = indent + "  ";
+  const body = wrapInDelimiters(
+    Object.entries(members).map(([key, value]) => {
+      const member = `${newIndent}${genObjectKey(key)}`;
+      if (value === undefined) {
+        return member;
+      }
+      return `${member} = ${
+        typeof value === "string" ? genString(value) : value
+      }`;
+    }),
+    indent,
+    "{}",
+  );
+  return [
+    options.export && "export",
+    options.const && "const",
+    `enum ${name}`,
+    body,
+  ]
+    .filter(Boolean)
+    .join(" ");
 }
 
 /**

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -231,4 +231,10 @@ describe("genEnum", () => {
       expect(code).to.equal(t.code);
     });
   }
+
+  it("throws for an uninitialized member after a string-initialized member", () => {
+    expect(() => genEnum("FooEnum", { A: "a", B: undefined })).to.throw(
+      /must have an initializer/,
+    );
+  });
 });

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -2,6 +2,7 @@ import { expect, describe, it } from "vitest";
 import {
   genInterface,
   genAugmentation,
+  genEnum,
   genInlineTypeImport,
   genTypeImport,
   genTypeExport,
@@ -166,6 +167,67 @@ describe("genTypeExport", () => {
   for (const t of genTypeExportTests) {
     it(genTestTitle(t.code), () => {
       const code = genTypeExport(...t.input);
+      expect(code).to.equal(t.code);
+    });
+  }
+});
+
+const genEnumTests: Array<{
+  input: Parameters<typeof genEnum>;
+  code: string;
+}> = [
+  { input: ["FooEnum", {}], code: "enum FooEnum {}" },
+  {
+    input: ["Direction", { Up: undefined, Down: undefined }],
+    code: `enum Direction {
+  Up,
+  Down
+}`,
+  },
+  {
+    input: ["Status", { Ok: 200, NotFound: 404 }],
+    code: `enum Status {
+  Ok = 200,
+  NotFound = 404
+}`,
+  },
+  {
+    input: ["Color", { Red: "red", Green: "green" }],
+    code: `enum Color {
+  Red = "red",
+  Green = "green"
+}`,
+  },
+  {
+    input: ["FooEnum", { "foo bar": 1 }],
+    code: `enum FooEnum {
+  "foo bar" = 1
+}`,
+  },
+  {
+    input: ["FooEnum", { A: 0 }, { export: true }],
+    code: `export enum FooEnum {
+  A = 0
+}`,
+  },
+  {
+    input: ["FooEnum", { A: 0 }, { const: true }],
+    code: `const enum FooEnum {
+  A = 0
+}`,
+  },
+  {
+    input: ["FooEnum", { A: 0 }, { export: true, const: true }],
+    code: `export const enum FooEnum {
+  A = 0
+}`,
+  },
+];
+
+describe("genEnum", () => {
+  for (const t of genEnumTests) {
+    it(genTestTitle(t.code), () => {
+      const code = genEnum(...t.input);
       expect(code).to.equal(t.code);
     });
   }


### PR DESCRIPTION
Closes #123. Adds a `genEnum` codegen helper for TypeScript enums, with optional `export` and `const` modifiers, in response to the maintainer's "PR welcome to add" on that issue.

Member values are emitted as string literals or numbers, and members without a value are left for implicit enum numbering. Defaults emit a plain `enum`; behavior of existing helpers is unchanged. README is regenerated via automd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a TypeScript enum generator with support for export/const modifiers and both string and numeric members.

* **Documentation**
  * Added API documentation describing the enum generator.

* **Tests**
  * Added comprehensive tests covering plain, numeric, and string enums, quoted keys, modifier variants, and a negative case validating invalid member ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->