### PR TITLE
feat: add genExportDefault function for ESM export default support

### DIFF
--- a/src/esm.ts
+++ b/src/esm.ts
@@ -95,6 +95,37 @@ export function genExport(
 }
 
 /**
+ * Generate an ESM `export default` statement.
+ *
+ * String values that look like valid JS identifiers are emitted as bare names;
+ * all other values are serialized via `genString`.
+ *
+ * @example
+ *
+ * ```js
+ * genExportDefault("myFunction");
+ * // ~> `export default myFunction;`
+ *
+ * genExportDefault(42);
+ * // ~> `export default 42;`
+ *
+ * genExportDefault({ foo: "bar" });
+ * // ~> `export default {foo: "bar"};`
+ * ```
+ *
+ * @group ESM
+ */
+export function genExportDefault(
+  expression: unknown,
+  options: CodegenOptions = {},
+) {
+  if (typeof expression === "string" && VALID_IDENTIFIER_RE.test(expression)) {
+    return `export default ${expression};`;
+  }
+  return `export default ${genString(expression, options)};`;
+}
+
+/**
  * Generate an ESM dynamic `import()` statement.
  *
  * @group ESM

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -110,7 +110,7 @@ export function genExport(
  * // ~> `export default 42;`
  *
  * genExportDefault({ foo: "bar" });
- * // ~> `export default {foo: "bar"};`
+ * // ~> `export default {"foo":"bar"};`
  * ```
  *
  * @group ESM

--- a/test/esm.test.ts
+++ b/test/esm.test.ts
@@ -99,6 +99,14 @@ const genExportDefaultTests = [
     code: `export default myFunction;`,
     options: { singleQuotes: true },
   },
+  // Non-identifier strings (should be quoted)
+  { expression: "my-function", code: 'export default "my-function";' },
+  { expression: "hello world", code: 'export default "hello world";' },
+  {
+    expression: "my-function",
+    code: `export default 'my-function';`,
+    options: { singleQuotes: true },
+  },
 ];
 
 describe("genExportDefault", () => {

--- a/test/esm.test.ts
+++ b/test/esm.test.ts
@@ -2,6 +2,7 @@ import { expect, describe, it } from "vitest";
 import {
   genImport,
   genExport,
+  genExportDefault,
   genDynamicImport,
   genSafeVariableName,
   genDynamicTypeImport,
@@ -75,6 +76,35 @@ describe("genExport", () => {
   for (const t of genExportTests) {
     it(genTestTitle(t.code), () => {
       const code = genExport("pkg", t.names, t.options);
+      expect(code).to.equal(t.code);
+    });
+  }
+});
+
+const genExportDefaultTests = [
+  { expression: "myFunction", code: 'export default myFunction;' },
+  { expression: undefined, code: 'export default undefined;' },
+  { expression: 42, code: 'export default 42;' },
+  { expression: null, code: 'export default null;' },
+  {
+    expression: { foo: "bar" },
+    code: 'export default {"foo":"bar"};',
+  },
+  {
+    expression: ["a", "b"],
+    code: 'export default ["a","b"];',
+  },
+  {
+    expression: "myFunction",
+    code: `export default myFunction;`,
+    options: { singleQuotes: true },
+  },
+];
+
+describe("genExportDefault", () => {
+  for (const t of genExportDefaultTests) {
+    it(genTestTitle(t.code), () => {
+      const code = genExportDefault(t.expression, t.options);
       expect(code).to.equal(t.code);
     });
   }


### PR DESCRIPTION
## Problem

knitwork supports generating `import`, `export`, and `dynamic import` statements, but there is no way to generate `export default <expression>`.

## Changes

Added `genExportDefault(expression, options?)` function that generates `export default <expression>;` statements.

- String values that are valid JS identifiers are emitted as bare names (e.g., `genExportDefault("myFunction")` → `export default myFunction;`)
- All other values are serialized via `genString` (e.g., `genExportDefault(42)` → `export default 42;`, `genExportDefault({ foo: "bar" })` → `export default {"foo":"bar"};`)

## Why

This fills a gap in the ESM API. While `export default` is a fundamental ES module syntax, there was no dedicated function for it. Users had to manually construct the string.

Closes #77


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a helper to generate default module exports with intelligent handling of identifiers, literals, objects/arrays, and configurable string-quoting options.

* **Tests**
  * Added a comprehensive test suite validating export-generation behavior across undefined, null, numeric, object/array, identifier, and string cases, including formatting option variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->