### PR TITLE
feat: add genExportDefault for ESM export default support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,25 @@ Generate an ESM type `import()` statement.
 
 Generate an ESM `export` statement.
 
+### `genExportDefault(expression)`
+
+Generate an ESM `export default` statement.
+
+The expression is used as-is and is not escaped or quoted. Use a serialization helper such as `genObjectFromValues` or `JSON.stringify` to generate the expression from a runtime value.
+
+**Example:**
+
+```js
+genExportDefault("foo");
+// ~> `export default foo;`
+
+genExportDefault("{ foo: 1 }");
+// ~> `export default { foo: 1 };`
+
+genExportDefault("() => {}");
+// ~> `export default () => {};`
+```
+
 ### `genImport(specifier, imports?, options)`
 
 Generate an ESM `import` statement.

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -95,6 +95,32 @@ export function genExport(
 }
 
 /**
+ * Generate an ESM `export default` statement.
+ *
+ * The expression is used as-is and is not escaped or quoted. Use a
+ * serialization helper such as `genObjectFromValues` or `JSON.stringify` to
+ * generate the expression from a runtime value.
+ *
+ * @example
+ *
+ * ```js
+ * genExportDefault("foo");
+ * // ~> `export default foo;`
+ *
+ * genExportDefault("{ foo: 1 }");
+ * // ~> `export default { foo: 1 };`
+ *
+ * genExportDefault("() => {}");
+ * // ~> `export default () => {};`
+ * ```
+ *
+ * @group ESM
+ */
+export function genExportDefault(expression: string) {
+  return `export default ${expression};`;
+}
+
+/**
  * Generate an ESM dynamic `import()` statement.
  *
  * @group ESM

--- a/test/esm.test.ts
+++ b/test/esm.test.ts
@@ -2,6 +2,7 @@ import { expect, describe, it } from "vitest";
 import {
   genImport,
   genExport,
+  genExportDefault,
   genDynamicImport,
   genSafeVariableName,
   genDynamicTypeImport,
@@ -75,6 +76,23 @@ describe("genExport", () => {
   for (const t of genExportTests) {
     it(genTestTitle(t.code), () => {
       const code = genExport("pkg", t.names, t.options);
+      expect(code).to.equal(t.code);
+    });
+  }
+});
+
+const genExportDefaultTests = [
+  { expression: "foo", code: "export default foo;" },
+  { expression: "{ foo: 1 }", code: "export default { foo: 1 };" },
+  { expression: "() => {}", code: "export default () => {};" },
+  { expression: '"hello"', code: 'export default "hello";' },
+  { expression: "42", code: "export default 42;" },
+];
+
+describe("genExportDefault", () => {
+  for (const t of genExportDefaultTests) {
+    it(genTestTitle(t.code), () => {
+      const code = genExportDefault(t.expression);
       expect(code).to.equal(t.code);
     });
   }


### PR DESCRIPTION
Closes #77

## Problem

knitwork can generate `import`, `export`, and dynamic `import()` statements, but there is no helper for generating `export default <expression>`.

## Changes

Adds `genExportDefault(expression)` which returns an `export default <expression>;` statement.

The expression is used **as-is** (raw, not escaped or quoted), consistent with knitwork's existing raw-expression helpers such as `genObjectFromRaw`. Serialization of runtime values is left to the caller, e.g. `genObjectFromValues(...)` or `JSON.stringify(...)`. This keeps the API unambiguous and composable rather than guessing whether a string is a value or an expression.

```js
genExportDefault("foo");
// ~> export default foo;

genExportDefault("() => {}");
// ~> export default () => {};

genExportDefault(genObjectFromValues({ foo: "bar" }));
// ~> export default { foo: "bar" };
```

- `src/esm.ts`: implement and document `genExportDefault`
- `test/esm.test.ts`: add cases for identifiers, objects, arrow functions, strings, and numbers
- `README.md`: regenerated via automd from the new JSDoc

## Validation

- `pnpm vitest run` — 64 tests passing (5 new)
- `pnpm lint` — eslint + prettier clean
- `pnpm build` — unbuild succeeds, `genExportDefault` exported in both ESM and CJS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new helper to generate ESM `export default` statements from a provided expression.
  * The helper supports a range of valid JavaScript expressions, including objects, functions, strings, and numbers.

* **Documentation**
  * Expanded the README with clearer usage guidance and examples showing the generated output format.
  * Added a note explaining that expressions are inserted directly, along with a recommendation to use serialization helpers when needed.

* **Tests**
  * Added coverage for multiple expression types to verify the generated output matches expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->