### PR TITLE
feat(typescript): support declare global and declare namespace codegen

### DIFF
--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -93,7 +93,7 @@ export function genInterface(
 }
 
 /**
- * Generate typescript `declare module` augmentation.
+ * Generate typescript `declare module` or `declare global` augmentation.
  *
  * @group Typescript
  */
@@ -104,7 +104,37 @@ export function genAugmentation(
     TypeObject | [TypeObject, Omit<GenInterfaceOptions, "export">]
   >,
 ): string {
-  return `declare module ${genString(specifier)} ${wrapInDelimiters(
+  const statement =
+    specifier === "global"
+      ? "declare global"
+      : `declare module ${genString(specifier)}`;
+  return `${statement} ${wrapInDelimiters(
+    Object.entries(interfaces || {}).map(
+      ([key, entry]) =>
+        "  " +
+        (Array.isArray(entry)
+          ? genInterface(key, ...entry)
+          : genInterface(key, entry, {}, "  ")),
+    ),
+    undefined,
+    undefined,
+    false,
+  )}`;
+}
+
+/**
+ * Generate typescript `declare namespace` statement.
+ *
+ * @group Typescript
+ */
+export function genNamespace(
+  name: string,
+  interfaces?: Record<
+    string,
+    TypeObject | [TypeObject, Omit<GenInterfaceOptions, "export">]
+  >,
+): string {
+  return `declare namespace ${name} ${wrapInDelimiters(
     Object.entries(interfaces || {}).map(
       ([key, entry]) =>
         "  " +

--- a/test/typescript.test.ts
+++ b/test/typescript.test.ts
@@ -2,6 +2,7 @@ import { expect, describe, it } from "vitest";
 import {
   genInterface,
   genAugmentation,
+  genNamespace,
   genInlineTypeImport,
   genTypeImport,
   genTypeExport,
@@ -94,12 +95,46 @@ const genAugmentationTests: Array<{
   interface MyInterface extends OtherInterface, FurtherInterface {}
 }`,
   },
+  { input: ["global"], code: "declare global {}" },
+  {
+    input: ["global", { Window: {} }],
+    code: `declare global {
+  interface Window {}
+}`,
+  },
 ];
 
 describe("genAugmentation", () => {
   for (const t of genAugmentationTests) {
     it(genTestTitle(t.code), () => {
       const code = genAugmentation(...t.input);
+      expect(code).to.equal(t.code);
+    });
+  }
+});
+
+const genNamespaceTests: Array<{
+  input: Parameters<typeof genNamespace>;
+  code: string;
+}> = [
+  { input: ["MyNamespace"], code: "declare namespace MyNamespace {}" },
+  {
+    input: [
+      "MyNamespace",
+      {
+        MyInterface: {},
+      },
+    ],
+    code: `declare namespace MyNamespace {
+  interface MyInterface {}
+}`,
+  },
+];
+
+describe("genNamespace", () => {
+  for (const t of genNamespaceTests) {
+    it(genTestTitle(t.code), () => {
+      const code = genNamespace(...t.input);
       expect(code).to.equal(t.code);
     });
   }


### PR DESCRIPTION
## Problem

TypeScript augmentations for `declare global` and `declare namespace <name>` were not directly supported by `genAugmentation` (which always generated `declare module "..."`).

## Root Cause

`genAugmentation` always wrapped the input specifier in `genString(specifier)` and prefixed with `declare module`. In TypeScript, `declare global` is a reserved declaration keyword without quotes or `module` keyword.

## Fix

- Updated `genAugmentation` to emit `declare global` when `specifier === "global"`.
- Added `genNamespace` helper to generate `declare namespace <name> { ... }` declarations.

## Testing

- Added unit tests in `test/typescript.test.ts` for `declare global` and `declare namespace`.
- Verified all 63 unit tests and linter pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for generating TypeScript namespace declarations.
  - Added support for generating global declarations, including global interface extensions.
  - Module augmentation generation continues to support named modules.

- **Tests**
  - Added coverage for empty namespaces, namespaces containing interfaces, and global augmentations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->